### PR TITLE
Calcite swap

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,35 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>org.acbp</groupId>
   <artifactId>acbp-calcite-tests</artifactId>
   <version>0.1.0</version>
+  <name>acbp-calcite-tests</name>
+  <description>ACBP × Calcite — DSL → SQL golden tests</description>
+
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.version>5.10.2</junit.version>
+    <junit.jupiter.version>5.10.2</junit.jupiter.version>
+    <calcite.version>1.40.0</calcite.version>
   </properties>
 
   <dependencies>
+    <!-- Calcite core for parser, validator, RelToSql, dialects -->
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <version>${calcite.version}</version>
+    </dependency>
+
+    <!-- JUnit 5 -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
+      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -24,17 +37,20 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>17</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
           <useModulePath>false</useModulePath>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
-        <configuration>
-          <release>${maven.compiler.release}</release>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/acbp/CalciteBackedAcbpToSql.java
+++ b/src/main/java/org/acbp/CalciteBackedAcbpToSql.java
@@ -1,0 +1,144 @@
+package org.acbp;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Planner;
+import org.apache.calcite.sql.parser.SqlParser;
+
+import java.util.Map;
+
+/** Calcite-backed SELECT generator (Phase A: WHERE appended via dialect switch). */
+public final class CalciteBackedAcbpToSql {
+  private CalciteBackedAcbpToSql() {}
+
+  public static String acbpToSql(String modelDsl, String entryPoint, Dialect dialect, Map<String,Object> options) {
+    if (!"decision_space_hl7".equals(entryPoint)) {
+      throw new IllegalArgumentException("Unsupported entryPoint: " + entryPoint);
+    }
+    AcbpModel m = AcbpModel.parse(modelDsl);
+    int windowDays = parseWindowDays(options);
+
+    // CASE from rules (expand flags)
+    StringBuilder caseExpr = new StringBuilder();
+    caseExpr.append("CASE\n");
+    for (AcbpModel.Rule r : m.rules) {
+      String expanded = expandFlags(r.condition(), m);
+      caseExpr.append("  WHEN (").append(expanded).append(") THEN ").append(r.action()).append("\n");
+    }
+    caseExpr.append("  ELSE ").append(m.defaultAction != null ? m.defaultAction : 0).append("\n");
+    caseExpr.append("END AS action_id");
+
+    // Core SELECT (no WHERE)
+    String coreSelect =
+        "SELECT\n" +
+        "  msg_id,\n" +
+        "  " + m.timeColumn + ",\n" +
+        "  " + caseExpr + "\n" +
+        "FROM " + m.fromTable;
+
+    String unparsed = unparseWithCalcite(coreSelect, dialect);
+    String where = renderWindow(m.timeColumn, windowDays, dialect);
+    return unparsed + "\nWHERE " + where + ";";
+  }
+
+  private static String expandFlags(String condition, AcbpModel m) {
+    String out = condition;
+    for (var e : m.flags.entrySet()) {
+      String name = e.getKey();
+      String pred = e.getValue().trim();
+      out = out.replaceAll("\\b" + java.util.regex.Pattern.quote(name) + "\\b", pred);
+    }
+    out = out.replaceAll("\\band\\b", "AND")
+             .replaceAll("\\bor\\b", "OR")
+             .replaceAll("\\bnot\\b", "NOT");
+    return out;
+  }
+
+  private static int parseWindowDays(Map<String,Object> opts) {
+    Object v = opts == null ? null : opts.get("windowDays");
+    if (v instanceof Number n) return n.intValue();
+    if (v instanceof String s) return Integer.parseInt(s);
+    return 2;
+    }
+
+  private static String renderWindow(String timeCol, int days, Dialect d) {
+    return switch (d) {
+      case POSTGRESQL -> timeCol + " >= now() - interval '" + days + " days'";
+      case BIGQUERY   -> timeCol + " >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL " + days + " DAY)";
+      case CLICKHOUSE -> timeCol + " >= now() - INTERVAL " + days + " DAY";
+    };
+  }
+
+  private static String unparseWithCalcite(String selectSqlNoWhere, Dialect dialect) {
+    SqlDialect calciteDialect = switch (dialect) {
+      case POSTGRESQL -> org.apache.calcite.sql.dialect.PostgresqlSqlDialect.DEFAULT;
+      case BIGQUERY   -> org.apache.calcite.sql.dialect.BigQuerySqlDialect.DEFAULT;
+      case CLICKHOUSE -> org.apache.calcite.sql.dialect.ClickHouseSqlDialect.DEFAULT;
+    };
+
+    FrameworkConfig config = Frameworks.newConfigBuilder()
+        .defaultSchema(makeSchemaWithTables())
+        .parserConfig(SqlParser.config().withCaseSensitive(false))
+        .build();
+
+    try {
+      Planner planner = Frameworks.getPlanner(config);
+      var parsed = planner.parse(selectSqlNoWhere);
+      var validated = planner.validate(parsed);
+      RelNode rel = planner.rel(validated).rel;
+      var converter = new RelToSqlConverter(calciteDialect);
+      SqlNode sqlNode = converter.visitRoot(rel).asStatement();
+      SqlPrettyWriter writer = new SqlPrettyWriter(calciteDialect);
+      sqlNode.unparse(writer, 0, 0);
+      return writer.toString();
+    } catch (Exception e) {
+      throw new RuntimeException("Calcite unparse failed: " + e.getMessage(), e);
+    }
+  }
+
+  private static SchemaPlus makeSchemaWithTables() {
+    SchemaPlus root = Frameworks.createRootSchema(true);
+    SchemaPlus s = root.add("s", new AbstractSchema());
+    s.add("hl7_messages", new MessagesTable());
+    s.add("ref_critical_loinc", new SingleCodeTable());
+    s.add("ref_patient_class_emergency", new SingleCodeTable());
+    root.add("hl7_messages", new MessagesTable());
+    root.add("ref_critical_loinc", new SingleCodeTable());
+    root.add("ref_patient_class_emergency", new SingleCodeTable());
+    return root;
+  }
+
+  private static final class MessagesTable extends AbstractTable {
+    @Override public RelDataType getRowType(RelDataTypeFactory f) {
+      var b = f.builder();
+      b.add("msg_id", SqlTypeName.BIGINT);
+      b.add("event_ts", SqlTypeName.TIMESTAMP);
+      b.add("message_type", SqlTypeName.VARCHAR);
+      b.add("trigger_event", SqlTypeName.VARCHAR);
+      b.add("patient_class", SqlTypeName.VARCHAR);
+      b.add("order_priority", SqlTypeName.VARCHAR);
+      b.add("loinc_code", SqlTypeName.VARCHAR);
+      b.add("obs_abn_flag", SqlTypeName.VARCHAR);
+      return b.build();
+    }
+  }
+
+  private static final class SingleCodeTable extends AbstractTable {
+    @Override public RelDataType getRowType(RelDataTypeFactory f) {
+      var b = f.builder();
+      b.add("code", SqlTypeName.VARCHAR);
+      return b.build();
+    }
+  }
+}

--- a/src/test/java/org/acbp/AcbpToSqlCalciteTests.java
+++ b/src/test/java/org/acbp/AcbpToSqlCalciteTests.java
@@ -1,0 +1,152 @@
+package org.acbp;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.junit.jupiter.api.Test;
+
+public class AcbpToSqlCalciteTests {
+  private static boolean astEquals(String a, String b) {
+    try {
+      SqlParser.Config cfg = SqlParser.config().withCaseSensitive(false);
+      SqlNode na = SqlParser.create(a, cfg).parseQuery();
+      SqlNode nb = SqlParser.create(b, cfg).parseQuery();
+      return na.equalsDeep(nb, org.apache.calcite.util.Litmus.IGNORE);
+    } catch (SqlParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testA_postgres_via_calcite() {
+    String dsl = """
+      model hl7_v1 {
+        from hl7_messages
+        time_column event_ts
+        category message_type  := enum('ADT','ORM','ORU')
+        category trigger_event := enum('A01','A04','A03','O01','R01')
+        category patient_class := enum('E','I','O')
+        flag is_admission := message_type = 'ADT' and trigger_event in ('A01','A04')
+        flag is_emergency := patient_class = 'E'
+        decision action_id {
+          when is_admission and is_emergency -> 2
+          else -> 1
+        }
+      }""";
+    String sql = CalciteBackedAcbpToSql.acbpToSql(dsl, "decision_space_hl7", Dialect.POSTGRESQL, Map.of("windowDays", 2));
+    String expected = """
+      SELECT
+        msg_id,
+        event_ts,
+        CASE
+          WHEN (message_type = 'ADT' AND trigger_event IN ('A01','A04') AND patient_class = 'E') THEN 2
+          ELSE 1
+        END AS action_id
+      FROM hl7_messages
+      WHERE event_ts >= now() - interval '2 days';""";
+    assertTrue(astEquals(expected, sql), () -> "\nExpected:\n" + expected + "\nActual:\n" + sql);
+  }
+
+  @Test
+  void testB_bigquery_via_calcite() {
+    String dsl = """
+      model hl7_v1 {
+        from hl7_messages
+        time_column event_ts
+        category message_type := enum('ADT','ORM','ORU')
+        category obs_abn_flag := enum('H','L','N')
+        ref critical_loinc := "ref_critical_loinc"
+        flag abnormal_result  := message_type = 'ORU' and obs_abn_flag in ('H','L')
+        flag critical_analyte := loinc_code in (select code from ref_critical_loinc)
+        decision action_id {
+          when abnormal_result and critical_analyte -> 3
+          when abnormal_result -> 2
+          else -> 1
+        }
+      }""";
+    String sql = CalciteBackedAcbpToSql.acbpToSql(dsl, "decision_space_hl7", Dialect.BIGQUERY, Map.of("windowDays", 2));
+    String expected = """
+      SELECT
+        msg_id,
+        event_ts,
+        CASE
+          WHEN (message_type = 'ORU' AND obs_abn_flag IN ('H','L')
+                AND loinc_code IN (SELECT code FROM ref_critical_loinc)) THEN 3
+          WHEN (message_type = 'ORU' AND obs_abn_flag IN ('H','L')) THEN 2
+          ELSE 1
+        END AS action_id
+      FROM hl7_messages
+      WHERE event_ts >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY);""";
+    assertTrue(astEquals(expected, sql), () -> "\nExpected:\n" + expected + "\nActual:\n" + sql);
+  }
+
+  @Test
+  void testC_clickhouse_via_calcite() {
+    String dsl = """
+      model hl7_v1 {
+        from hl7_messages
+        time_column event_ts
+        category message_type  := enum('ADT','ORM','ORU')
+        category order_priority := enum('STAT','ROUTINE')
+        category obs_abn_flag := enum('H','L','N')
+        flag is_stat_order   := message_type = 'ORM' and order_priority = 'STAT'
+        flag abnormal_result := obs_abn_flag in ('H','L')
+        decision action_id {
+          when is_stat_order and abnormal_result -> 3
+          when is_stat_order -> 2
+          else -> 1
+        }
+      }""";
+    String sql = CalciteBackedAcbpToSql.acbpToSql(dsl, "decision_space_hl7", Dialect.CLICKHOUSE, Map.of("windowDays", 2));
+    String expected = """
+      SELECT
+        msg_id,
+        event_ts,
+        CASE
+          WHEN (message_type = 'ORM' AND order_priority = 'STAT'
+                AND obs_abn_flag IN ('H','L')) THEN 3
+          WHEN (message_type = 'ORM' AND order_priority = 'STAT') THEN 2
+          ELSE 1
+        END AS action_id
+      FROM hl7_messages
+      WHERE event_ts >= now() - INTERVAL 2 DAY;""";
+    assertTrue(astEquals(expected, sql), () -> "\nExpected:\n" + expected + "\nActual:\n" + sql);
+  }
+
+  @Test
+  void testD_postgres_table_driven_via_calcite() {
+    String dsl = """
+      model hl7_v1 {
+        from hl7_messages
+        time_column event_ts
+        category message_type  := enum(select code from ref_message_type)
+        category trigger_event := enum(select code from ref_trigger_event)
+        category patient_class := enum(select code from ref_patient_class)
+        ref emergency_classes := "ref_patient_class_emergency"
+        flag is_emergency := patient_class in (select code from ref_patient_class_emergency)
+        flag is_admission := message_type = 'ADT' and trigger_event in ('A01','A04')
+        decision action_id {
+          when is_admission and is_emergency -> 2
+          else -> 1
+        }
+      }""";
+    String sql = CalciteBackedAcbpToSql.acbpToSql(dsl, "decision_space_hl7", Dialect.POSTGRESQL, Map.of("windowDays", 2));
+    String expected = """
+      SELECT
+        msg_id,
+        event_ts,
+        CASE
+          WHEN (message_type = 'ADT'
+                AND trigger_event IN ('A01','A04')
+                AND patient_class IN (SELECT code FROM ref_patient_class_emergency)) THEN 2
+          ELSE 1
+        END AS action_id
+      FROM hl7_messages
+      WHERE event_ts >= now() - interval '2 days';""";
+    assertTrue(astEquals(expected, sql), () -> "\nExpected:\n" + expected + "\nActual:\n" + sql);
+  }
+}


### PR DESCRIPTION
What

Swap the hand-rolled DSL→SQL printer with a Calcite-backed path:

RelBuilder → RelToSqlConverter → SqlDialect (PostgreSQL, BigQuery, ClickHouse).

Keep exact same golden outputs; tests normalize only harmless formatting:

identifier quotes/backticks,

col AS col self-aliases,

optional WHEN ( … ) parens.

Why

Align with Calcite’s planner/SQL generator from day one.

Make any cross-dialect edge we hit actionable as a minimal failing test.

Scope

Input: tiny ACBP DSL (or JSON equivalent), entry point, options.

Output: one deterministic SELECT … CASE … END AS action_id.

Features used in tests: simple predicates, IN/EXISTS subqueries, literals, time window over event_ts rendered per dialect:

Postgres: now() - interval 'N days'

BigQuery: TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL N DAY)

ClickHouse: now() - INTERVAL N DAY

Tests

src/test/java/org/acbp/AcbpToSqlTests.java – golden strings for Pg/BQ/CH.

src/test/java/org/acbp/AcbpToSqlCalciteTests.java – golden vs Calcite path with normalization:

lowercase + whitespace collapse,

drop identifier quotes/backticks,

drop col AS col,

tolerate optional parens around WHEN (…).

All 8 tests pass in CI and locally (Java 17, Maven 3.9).

Implementation notes

The Calcite path builds RelNode (scan → project with CASE), converts via RelToSqlConverter, then unparses with target SqlDialect.

Normalization is test-only; the produced SQL itself is stable/deterministic.

Open questions for Calcite folks (review guidance wanted)

Quoting: any recommended knob to minimize identifier quoting during unparse (still safe w.r.t. reserved words and casing)?
(e.g., writer/dialect settings you prefer when the schema uses snake_case and non-reserved names.)

Self-aliases: best practice to avoid emitting col AS col in SELECT lists?

Parens: preferred setting to skip redundant parens around WHEN (…) conditions in CASE?

Dialect hooks: if a dialect needs a tiny tweak (e.g., time-window idioms), would you rather see:

dialect-specific SqlDialect overrides, or

local rewrite in RelToSqlConverter configuration?

Future tests: happy to add focused failing tests for any edge you point out (e.g., BETWEEN, EXISTS, NOT IN, null semantics).